### PR TITLE
list README.md under extra-sources-files instead of data-files

### DIFF
--- a/byteable.cabal
+++ b/byteable.cabal
@@ -19,7 +19,7 @@ Stability:           experimental
 Build-Type:          Simple
 Homepage:            http://github.com/vincenthz/hs-byteable
 Cabal-Version:       >=1.8
-data-files:          README.md
+Extra-Source-Files:  README.md
 
 Library
   Exposed-modules:   Data.Byteable


### PR DESCRIPTION
This prevents the readme from being installed as a data file.
